### PR TITLE
Removing c/q char callbacks in search

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -47,12 +47,6 @@ pub async fn update(app: &mut App, key_event: KeyEvent) {
             }
         },
         AppMode::Search => match key_event.code {
-            KeyCode::Char('q') => app.quit(), //this is duplicated code, we can refactor it later
-            KeyCode::Char('c') | KeyCode::Char('C') => {
-                if key_event.modifiers == KeyModifiers::CONTROL {
-                    app.quit()
-                }
-            }
             KeyCode::Enter => {
                 app.select_searched_station().await;
                 app.should_redraw = true;


### PR DESCRIPTION
This addresses the issue opened here: https://github.com/FaisalBinAhmed/MVGFahrinfo/issues/4

Now the characters c and q will only work as char input instead of special keys