### PR TITLE
Migrate to tokio unbounded channel from std mpsc and other bug fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mvgfahrinfo"
 description = "Get up-to-date departure times for Munich public transport in your terminal."
-version = "1.0.1"
+version = "1.0.5"
 edition = "2021"
 
 author = "Faisal Ahmed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mvgfahrinfo"
 description = "Get up-to-date departure times for Munich public transport in your terminal."
-version = "1.0.5"
+version = "1.1.0"
 edition = "2021"
 
 author = "Faisal Ahmed"

--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ I might provide some pre-built binaries for Windows/MacOS/Linux in the future. :
 ## License
 
 MIT
+
+### Limitations
+
+Currently, the app only handles ASCII or 1 byte utf-8 character input. If you are searching a station with non-ascii characters in its name, the app will ignore the input. Please type the closeset characters & scroll a bit down to see the station in the list and select it (this will be fixed at a later version.)

--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ MIT
 
 ### Limitations
 
-Currently, the app only handles ASCII or 1 byte utf-8 character input. If you are searching a station with non-ascii characters in its name, the app will ignore the input. Please type the closeset characters & scroll a bit down to see the station in the list and select it (this will be fixed at a later version.)
+Currently, the app only handles ASCII or 1 byte UTF-8 character input. If you are searching a station with non-ascii characters (i.e. ö,ß etc.) in its name, the app will ignore the input. Please type the closest characters & scroll a bit down to select the station from the list (this will be fixed at a later version.)

--- a/src/app.rs
+++ b/src/app.rs
@@ -95,6 +95,7 @@ impl App {
                 // we don't update the departures if the api call returns an error variant
                 self.departures = departures;
                 self.update_last_refreshed();
+                self.should_redraw = true;
             }
         }
     }

--- a/src/components/station_list.rs
+++ b/src/components/station_list.rs
@@ -244,8 +244,8 @@ pub fn get_suggested_station_list(app: &mut App) -> List {
         .filter(|station| {
             station
                 .name
-                .to_lowercase()
-                .contains(&app.query.to_lowercase())
+                .to_ascii_lowercase()
+                .contains(&app.query.to_ascii_lowercase())
         })
         .map(|station| {
             suggested_stations.push(station.clone());

--- a/src/components/station_list.rs
+++ b/src/components/station_list.rs
@@ -11,7 +11,7 @@ use crate::{
     constants::{get_sbahn_color, get_ubahn_color},
     App,
 };
-
+// this is used in the Station List tab
 pub fn get_station_list_widget(app: &App) -> List {
     return List::new(
         app.stations
@@ -32,7 +32,7 @@ pub fn get_station_list_widget(app: &App) -> List {
     )
     .highlight_style(
         Style::default()
-            .bg(Color::Rgb(38, 35, 53))
+            .bg(Color::Rgb(38, 35, 38))
             .add_modifier(Modifier::BOLD),
     );
     // .highlight_symbol(">> ");
@@ -104,13 +104,10 @@ pub fn display_departures_table(departures: &[api::DepartureInfo]) -> Table {
             }),
         ];
         return Row::new(cells).height(1);
-        // .style(Style::default().fg(Color::White)); // no effect
     });
 
     let t = Table::new(rows)
         .header(header)
-        // .highlight_style(Style::default().fg(Color::Yellow))
-        // .highlight_symbol(">> ")
         .style(Style::default().fg(Color::White))
         .widths(&[
             Constraint::Percentage(20),
@@ -120,34 +117,6 @@ pub fn display_departures_table(departures: &[api::DepartureInfo]) -> Table {
         ]);
     t
 }
-
-// pub fn display_departures(departures: &Vec<api::DepartureInfo>) -> List {
-//     return List::new(
-//         departures
-//             .iter()
-//             .enumerate()
-//             .map(|(_index, departure)| {
-//                 ListItem::new(vec![
-//                     Line::from(vec![
-//                         get_vehicle_label(&departure.label, &departure.transport_type),
-//                         Span::styled(
-//                             format!(" {}", departure.destination),
-//                             Style::default().fg(Color::LightCyan),
-//                         ),
-//                         Span::styled(
-//                             format!(
-//                                 " ({}) min",
-//                                 get_minutes(departure.realtime_departure_time.clone())
-//                             ),
-//                             Style::default().fg(Color::White),
-//                         ),
-//                     ]),
-//                     // Line::from(get_product_icon_spans(&station.products)),
-//                 ])
-//             })
-//             .collect::<Vec<ListItem>>(),
-//     );
-// }
 
 fn get_platform_number<'a>(platform: Option<i64>, index: usize) -> Span<'a> {
     let bg = if index % 2 == 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-// #[allow(unused, dead_code)]
 use anyhow::Result; //to avoid writing the error type <Box dyn Error> everywhere
 
 pub mod api;
@@ -47,7 +46,7 @@ async fn main() -> Result<()> {
             app.should_redraw = false;
         }
 
-        match tui.events.next()? {
+        match tui.events.next().await? {
             Event::Tick => {} //every 250ms we get a tick event, we ignore it
             Event::Key(key_event) => update(&mut app, key_event).await,
         };

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -28,7 +28,6 @@ pub fn render(app: &mut App, f: &mut Frame) {
     let block = Block::default();
     f.render_widget(block, size);
 
-    // let tab_names = ["Departures", "Station List"];
     let titles = ["Departures", "Station List"]
         .iter()
         .map(|t| {
@@ -108,7 +107,6 @@ pub fn render(app: &mut App, f: &mut Frame) {
             .block(Block::default().borders(Borders::ALL).title(popup_title))
             .style(Style::default().fg(Color::LightCyan))
             .alignment(ratatui::prelude::Alignment::Left);
-        // .block(block);
 
         let area = static_widgets::centered_rect(69, 50, f.size()); //size of the MODAL
 
@@ -137,7 +135,6 @@ pub fn render(app: &mut App, f: &mut Frame) {
         );
 
         f.render_stateful_widget(suggested_stations, chunks[1], search_scroll_state);
-        // f.render_widget(suggested_stations, chunks[1]);
     }
 }
 
@@ -153,7 +150,6 @@ fn draw_departures(f: &mut Frame<'_>, app: &App) {
         .padding(Padding::new(2, 2, 1, 1))
         .style(Style::default());
 
-    // let list = display_departures(&app.departures).block(block);
     let table = display_departures_table(&app.departures).block(block);
 
     let area = static_widgets::centered_rect(69, 50, f.size());

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,5 +1,3 @@
-use std::sync::mpsc;
-
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::widgets::ListState;
 
@@ -19,7 +17,7 @@ pub async fn update(app: &mut App, key_event: KeyEvent) {
             }
             KeyCode::Char('r') => {
                 app.update_departures().await;
-                app.should_redraw = true;
+                // app.should_redraw = true;
             }
             KeyCode::Down => {
                 app.increment_station();
@@ -89,7 +87,7 @@ pub async fn update(app: &mut App, key_event: KeyEvent) {
 // this lets us mutate the app state without having to pass a mutable reference and blocking the main ui/event thread or having to use a mutex
 // we simulate the refresh command by sending a key event to the event handler
 // the event handler has a mutable reference to the app and can mutate it
-pub fn initiate_auto_refresh(sender: mpsc::Sender<Event>) {
+pub fn initiate_auto_refresh(sender: tokio::sync::mpsc::UnboundedSender<Event>) {
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(60)).await;


### PR DESCRIPTION
- This converts the use of `std::sync::mpsc` to `tokio::sync::mpsc` for unbounded channel communication.
- This also handles the negative departure time shown in some stations.
- Handles non-ascii chars (UTF-8 size > 1 byte) by just ignoring them 😛 
- silghtly more greyish highlight color in station list tab
- cleanup and other bug fixes.