### PR TITLE
Feat: larger modal and semver bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "mvgfahrinfo"
 description = "Get up-to-date departure times for Munich public transport in your terminal."
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 
-author = "Faisal Ahmed"
+authors = ["Faisal Ahmed"]
 include = [
 	"src/**/*",
 	"Cargo.toml",

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -152,7 +152,7 @@ fn draw_departures(f: &mut Frame<'_>, app: &App) {
 
     let table = display_departures_table(&app.departures).block(block);
 
-    let area = static_widgets::centered_rect(69, 50, f.size());
+    let area = static_widgets::centered_rect(80, 69, f.size());
     f.render_widget(Clear, area); //this clears out the background
     f.render_widget(table, area);
 }


### PR DESCRIPTION
Just makes a modal a bit larger
- updates version to 1.1.1
<img width="1720" alt="Screenshot 2024-03-22 at 6 59 08 PM" src="https://github.com/FaisalBinAhmed/MVGFahrinfo/assets/20614782/2abd3735-100b-4137-847a-19ee3e247bf3">
