### PR TITLE
Fix: update to new API endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mvgfahrinfo"
 description = "Get up-to-date departure times for Munich public transport in your terminal."
-version = "1.1.1"
+version = "1.2.0"
 edition = "2021"
 
 authors = ["Faisal Ahmed"]

--- a/src/api.rs
+++ b/src/api.rs
@@ -25,7 +25,7 @@ pub struct StationInfo {
 }
 
 pub async fn fetch_station_info(id: &str) -> Result<Vec<StationInfo>> {
-    let full_url = format!("https://www.mvg.de/api/fib/v2/location?query={}", id);
+    let full_url = format!("https://www.mvg.de/api/bgw-pt/v3/departures?globalId={}", id);
 
     let resp = reqwest::get(full_url)
         .await?
@@ -59,7 +59,7 @@ pub struct DepartureInfo {
 }
 
 pub async fn get_departures(id: &str) -> Result<Vec<DepartureInfo>> {
-    let full_url = format!("https://www.mvg.de/api/fib/v2/departure?globalId={}", id);
+    let full_url = format!("https://www.mvg.de/api/bgw-pt/v3/departures?globalId={}", id);
 
     let resp = reqwest::get(full_url)
         .await?


### PR DESCRIPTION
As reported by #16, MVG recently updated their API endpoint and broke some functions of the app.

This PR updated the app to use the latest API endpoints.


Tested to work as before:

<img width="1271" alt="image" src="https://github.com/user-attachments/assets/55a2f24b-c217-4de2-9de6-816a661c2a55">
